### PR TITLE
Fixed video displaying in learningtopaint notebook

### DIFF
--- a/custom_learningtopaint.ipynb
+++ b/custom_learningtopaint.ipynb
@@ -69,6 +69,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install imageio==2.4.1"
+      ]
+    },
+    {
+      "cell_type": "code",
       "metadata": {
         "id": "TFN3oT1Hkjfs",
         "colab_type": "code",


### PR DESCRIPTION
Hi.
When running `custom_learningtopaint.ipynb` notebook in [colab](https://colab.research.google.com/github/mrm8488/shared_colab_notebooks/blob/master/custom_learningtopaint.ipynb) there is an error during displaying video:
`RuntimeError: imageio.ffmpeg.download() has been deprecated. Use 'pip install imageio-ffmpeg' instead.'`
![image](https://user-images.githubusercontent.com/36787333/216006122-d7e26f1e-0134-4128-8e81-695c589045b3.png)

Solution: [stackoverflow](https://stackoverflow.com/a/54919697)

Tested in colab: "Run all cells" without errors.