### PR TITLE
Fixed an error in case there is a whitespace in pic_name in `3D-Ken-Burns` notebook

### DIFF
--- a/3D_Ken_Burns.ipynb
+++ b/3D_Ken_Burns.ipynb
@@ -161,46 +161,6 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "w5PBRLqUGYbk",
-        "colab_type": "code",
-        "outputId": "72cec66f-cc73-4753-eb44-eeab4760c55f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 284
-        }
-      },
-      "source": [
-        "import chainer\n",
-        "chainer.print_runtime_info()"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Platform: Linux-4.14.137+-x86_64-with-Ubuntu-18.04-bionic\n",
-            "Chainer: 6.5.0\n",
-            "ChainerX: Not Available\n",
-            "NumPy: 1.17.4\n",
-            "CuPy:\n",
-            "  CuPy Version          : 6.5.0\n",
-            "  CUDA Root             : /usr/local/cuda\n",
-            "  CUDA Build Version    : 10010\n",
-            "  CUDA Driver Version   : 10010\n",
-            "  CUDA Runtime Version  : 10010\n",
-            "  cuDNN Build Version   : 7603\n",
-            "  cuDNN Version         : 7603\n",
-            "  NCCL Build Version    : 2402\n",
-            "  NCCL Runtime Version  : 2402\n",
-            "iDeep: 2.0.0.post3\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
         "id": "EkrEO7vIIPym",
         "colab_type": "code",
         "colab": {}
@@ -309,7 +269,7 @@
         "uploaded = files.upload()\n",
         "pic_name = list(uploaded.keys())[0]\n",
         "print(pic_name)\n",
-        "!mv ./$pic_name ./images/$pic_name"
+        "!mv ./\"$pic_name\" ./images/$pic_name"
       ],
       "execution_count": 0,
       "outputs": [
@@ -365,7 +325,7 @@
         }
       },
       "source": [
-        "!python autozoom.py --in ./images/$pic_name --out ./autozoom.mp4"
+        "!python autozoom.py --in ./images/\"$pic_name\" --out ./autozoom.mp4"
       ],
       "execution_count": 0,
       "outputs": [
@@ -488,9 +448,7 @@
         "colab_type": "code",
         "colab": {}
       },
-      "source": [
-        ""
-      ],
+      "source": [],
       "execution_count": 0,
       "outputs": []
     }


### PR DESCRIPTION
Hi.
Minor changes:
* removed 
```
import chainer
chainer.print_runtime_info()
```
because it's not installed at the moment is called
* fixed an error in case `pic_name` contains whitespaces